### PR TITLE
wrong option to print FIB's content, instead you must provide -b.

### DIFF
--- a/docs/TOPOLOGY.md
+++ b/docs/TOPOLOGY.md
@@ -181,7 +181,7 @@ Expected Output:
 Assuming that all three routers are configured correctly and converged, nfd-status
 in `/ndn/edu/colostate/%C1.Router/router2` will have the following entries for the
 name advertised by `/ndn/edu/memphis/%C1.Router/router1`. This output can be 
-seen by typing `nfd-status -f` in terminal
+seen by typing `nfd-status -b` in terminal
 
 FIB:
 


### PR DESCRIPTION
Dear admins,
small typo I've discovered going through the useful doc you've provided.
Best,
Salvo
