### PR TITLE
small typos into docs and into the conf template

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -67,7 +67,7 @@ router in memphis will do the following key creation and signing.
 
 NOTE: The first two steps may not apply to everyone as the root certificate and the site certificate are usually present at a testbed outside the scope of NLSR. These steps will help if you are testing an isolated testbed.
 
-   1. Create root key and self signed certificate with prefis `/ndn`
+   1. Create root key and self signed certificate with prefix `/ndn`
       $ndnsec-key-gen -n /ndn
       $ndnsec-sign-req /ndn > root.cert
       This root.cert will be configured by "cert-to-publish" commands in nlsr.conf
@@ -213,9 +213,9 @@ Here is the entire security configuraion of the router1 (As seen in nlsr.conf. N
       }
       cert-to-publish "root.cert" //optional, a file containing the root certificate. only the router
                                   //that is designated to publish root cert needs to specify this
-      cert-to-publish "site.cert" //optional, a file containing the root certificate. only the router
+      cert-to-publish "site.cert" //optional, a file containing the site certificate. only the router
                                   //that is designated to publish site cert need to specify this
-      cert-to-publish "operator.cert" //optional, a file containing the root certificate. only the
+      cert-to-publish "operator.cert" //optional, a file containing the operator certificate. only the
                                       //router that is designated to publish operator cert need to
                                       //specify this
       cert-to-publish "router.cert" //required, a file containing the router certificate.
@@ -226,7 +226,7 @@ that this router is responsible for hosting site keys and operator keys of color
 site.
 
    2. Generate key for site prefix `/ndn/edu/colorado`
-      $ndnsec-key-gen -n /ndn/edu/memphis > unsigned_site.cert
+      $ndnsec-key-gen -n /ndn/edu/colorado > unsigned_site.cert
 
       Send this cert to Memphis site ( as in example Memphis is the root) and get
       it signed by root. After you get back the site please put it in your convenient

--- a/docs/TOPOLOGY.md
+++ b/docs/TOPOLOGY.md
@@ -181,7 +181,7 @@ Expected Output:
 Assuming that all three routers are configured correctly and converged, nfd-status
 in `/ndn/edu/colostate/%C1.Router/router2` will have the following entries for the
 name advertised by `/ndn/edu/memphis/%C1.Router/router1`. This output can be 
-seen by typing `nfd-status -f` in terminal
+seen by typing `nfd-status -b` in terminal
 
 FIB:
 

--- a/nlsr.conf
+++ b/nlsr.conf
@@ -210,9 +210,9 @@ security
   }
   ; cert-to-publish "root.cert"  ; optional, a file containing the root certificate. only the router
                                  ; that is designated to publish root cert needs to specify this
-  ; cert-to-publish "site.cert"  ; optional, a file containing the root certificate. only the router
+  ; cert-to-publish "site.cert"  ; optional, a file containing the site certificate. only the router
                                  ; that is designated to publish site cert need to specify this
-  ; cert-to-publish "operator.cert" ; optional, a file containing the root certificate. only the
+  ; cert-to-publish "operator.cert" ; optional, a file containing the operator certificate. only the
                                     ; router that is designated to publish operator cert need to
                                     ; specify this
   cert-to-publish "router.cert"  ; required, a file containing the router certificate.


### PR DESCRIPTION
I changed the prefix into the key generation command from "/ndn/edu/memphis" to "/ndn/edu/colorado" just to be coherent with the rest of the tutorial, but I'm not sure that it could work, because in the template TOPOLOGY.MD, you've specified a different prefix "/ndn/edu/colostate" for router2.
Even if it worked, imho you should use just one prefix in both TOPOLOGY.md and SECURITY.md, because it could mislead/confuse users during the configuration.
